### PR TITLE
Fix Python 3 TypeErrors in t2kdm-maid.

### DIFF
--- a/t2kdm/maid.py
+++ b/t2kdm/maid.py
@@ -189,7 +189,7 @@ class Task(object):
 
     def get_logname(self):
         """Get a valid filename that can be used to log the output of the task."""
-        return base64.b64encode(str.encode(self.get_id()), altchars=str.encode("+_")) + str.encode(".txt")
+        return base64.b64encode(str.encode(self.get_id()), altchars=str.encode("+_")).decode() + ".txt"
 
     def get_id(self):
         """Return a string that identifies the task."""

--- a/t2kdm/maid.py
+++ b/t2kdm/maid.py
@@ -189,7 +189,7 @@ class Task(object):
 
     def get_logname(self):
         """Get a valid filename that can be used to log the output of the task."""
-        return base64.b64encode(self.get_id(), altchars="+_") + ".txt"
+        return base64.b64encode(str.encode(self.get_id()), altchars="+_") + ".txt"
 
     def get_id(self):
         """Return a string that identifies the task."""

--- a/t2kdm/maid.py
+++ b/t2kdm/maid.py
@@ -189,7 +189,7 @@ class Task(object):
 
     def get_logname(self):
         """Get a valid filename that can be used to log the output of the task."""
-        return base64.b64encode(str.encode(self.get_id()), altchars="+_") + ".txt"
+        return base64.b64encode(str.encode(self.get_id()), altchars=str.encode("+_")) + str.encode(".txt")
 
     def get_id(self):
         """Return a string that identifies the task."""

--- a/t2kdm/maid.py
+++ b/t2kdm/maid.py
@@ -189,7 +189,7 @@ class Task(object):
 
     def get_logname(self):
         """Get a valid filename that can be used to log the output of the task."""
-        return base64.b64encode(str.encode(self.get_id()), altchars=str.encode("+_")).decode() + ".txt"
+        return base64.b64encode(self.get_id().encode(), altchars="+_".encode()).decode() + ".txt"
 
     def get_id(self):
         """Return a string that identifies the task."""

--- a/t2kdm/maid.py
+++ b/t2kdm/maid.py
@@ -189,7 +189,10 @@ class Task(object):
 
     def get_logname(self):
         """Get a valid filename that can be used to log the output of the task."""
-        return base64.b64encode(self.get_id().encode(), altchars="+_".encode()).decode() + ".txt"
+        return (
+            base64.b64encode(self.get_id().encode(), altchars="+_".encode()).decode()
+            + ".txt"
+        )
 
     def get_id(self):
         """Return a string that identifies the task."""

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -167,10 +167,10 @@ class StorageElement(object):
 SEs = [
     StorageElement(
         "RAL-LCG2-T2K-tape",
-        host="srm-t2k.gridpp.rl.ac.uk",
+        host="x509up_u8000133@antares.stfc.ac.uk",
         type="tape",
         location="/europe/uk/ral",
-        basepath="srm://srm-t2k.gridpp.rl.ac.uk:8443/srm/managerv2?SFN=/castor/ads.rl.ac.uk/prod",
+        basepath="root://x509up_u8000133@antares.stfc.ac.uk:1094//eos/antares/prod",
     ),
     StorageElement(
         "UKI-SOUTHGRID-RALPP-disk",


### PR DESCRIPTION
Python 3 specific errors in `maid.py` have been fixed: `base64.b64encode` expects bytes-like objects as its arguments, which I've satisfied using `.encode()` methods. Also, the output of `base64.b64encode` must be a string so that it can be concatenated with `".txt"`, hence the addition of the `.decode()` method.