### PR TITLE
Updated RAL-LCG2-T2K-tape, IN2P3-CC-XRD-disk and IN2P3-CC-XRD-tape SEs, and replaced deprecated bringonline command.

### DIFF
--- a/t2kdm/backends.py
+++ b/t2kdm/backends.py
@@ -747,9 +747,7 @@ class DIRACBackend(GridBackend):
 
         self._xattr_cmd = sh.Command("gfal-xattr").bake(_tty_out=False)
         self._replica_checksum_cmd = sh.Command("gfal-sum").bake(_tty_out=False)
-        self._bringonline_cmd = sh.Command("gfal-bringonline").bake(
-            _tty_out=False
-        )
+        self._bringonline_cmd = sh.Command("gfal-bringonline").bake(_tty_out=False)
         self._cp_cmd = sh.Command("gfal-copy").bake(_tty_out=False)
         self._ls_se_cmd = sh.Command("gfal-ls").bake(color="never", _tty_out=False)
         self._move_cmd = sh.Command("gfal-rename").bake(_tty_out=False)

--- a/t2kdm/backends.py
+++ b/t2kdm/backends.py
@@ -747,7 +747,7 @@ class DIRACBackend(GridBackend):
 
         self._xattr_cmd = sh.Command("gfal-xattr").bake(_tty_out=False)
         self._replica_checksum_cmd = sh.Command("gfal-sum").bake(_tty_out=False)
-        self._bringonline_cmd = sh.Command("gfal-legacy-bringonline").bake(
+        self._bringonline_cmd = sh.Command("gfal-bringonline").bake(
             _tty_out=False
         )
         self._cp_cmd = sh.Command("gfal-copy").bake(_tty_out=False)

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -252,7 +252,7 @@ SEs = [
     StorageElement(
         "IN2P3-CC-disk",
         broken=True,
-        host="in2p3.fr",
+        host="polgrid4.in2p3.fr",
         type="disk",
         location="/europe/fr/in2p3",
         basepath="srm://polgrid4.in2p3.fr/dpm/in2p3.fr/home/t2k.org",

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -171,7 +171,8 @@ SEs = [
         host="antares.stfc.ac.uk",
         type="tape",
         location="/europe/uk/ral",
-        basepath="root://x509up_u%s@antares.stfc.ac.uk:1094//eos/antares/prod" % (os.getuid()),
+        basepath="root://x509up_u%s@antares.stfc.ac.uk:1094//eos/antares/prod"
+        % (os.getuid()),
     ),
     StorageElement(
         "UKI-SOUTHGRID-RALPP-disk",

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -244,11 +244,11 @@ SEs = [
     ),
     StorageElement(
         "IN2P3-CC-XRD-tape",
-        host="ccxroot.in2p3.fr:1097/xrootd/in2p3.fr/tape",
+        host="ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/tape",
         type="tape",
         location="/europe/fr/in2p3",
-        directpath="root://ccxrdli283.in2p3.fr:1094/xrootd/in2p3.fr/tape/t2k.org",
-        basepath="root://ccxroot.in2p3.fr:1097//xrootd/in2p3.fr/tape/t2k.org",
+        directpath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/tape/t2k.org",
+        basepath="root://ccxrdrli04.in2p3.fr:1097//xrootd/in2p3.fr/tape/t2k.org",
     ),
     StorageElement(
         "IN2P3-CC-disk",

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -235,7 +235,7 @@ SEs = [
     ),
     StorageElement(
         "IN2P3-CC-XRD-disk",
-        host="ccxroot.in2p3.fr:1097//xrootd/in2p3.fr/disk",
+        host="ccxroot.in2p3.fr:1097/xrootd/in2p3.fr/disk",
         type="disk",
         location="/europe/fr/in2p3",
         directpath="root://ccxrdli283.in2p3.fr:1094/xrootd/in2p3.fr/disk/t2k.org",
@@ -243,7 +243,7 @@ SEs = [
     ),
     StorageElement(
         "IN2P3-CC-XRD-tape",
-        host="ccxroot.in2p3.fr:1097//xrootd/in2p3.fr/tape",
+        host="ccxroot.in2p3.fr:1097/xrootd/in2p3.fr/tape",
         type="tape",
         location="/europe/fr/in2p3",
         directpath="root://ccxrdli283.in2p3.fr:1094/xrootd/in2p3.fr/tape/t2k.org",

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -236,11 +236,11 @@ SEs = [
     ),
     StorageElement(
         "IN2P3-CC-XRD-disk",
-        host="ccxroot.in2p3.fr:1097/xrootd/in2p3.fr/disk",
+        host="ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/disk",
         type="disk",
         location="/europe/fr/in2p3",
-        directpath="root://ccxrdli283.in2p3.fr:1094/xrootd/in2p3.fr/disk/t2k.org",
-        basepath="root://ccxroot.in2p3.fr:1097//xrootd/in2p3.fr/disk/t2k.org",
+        directpath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/disk/t2k.org",
+        basepath="root://ccxrdrli04.in2p3.fr:1097//xrootd/in2p3.fr/disk/t2k.org",
     ),
     StorageElement(
         "IN2P3-CC-XRD-tape",

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -3,6 +3,7 @@
 import posixpath
 import t2kdm as dm
 from six import print_
+import os
 
 
 class StorageElement(object):
@@ -167,10 +168,10 @@ class StorageElement(object):
 SEs = [
     StorageElement(
         "RAL-LCG2-T2K-tape",
-        host="x509up_u8000133@antares.stfc.ac.uk",
+        host="antares.stfc.ac.uk",
         type="tape",
         location="/europe/uk/ral",
-        basepath="root://x509up_u8000133@antares.stfc.ac.uk:1094//eos/antares/prod",
+        basepath="root://x509up_u%s@antares.stfc.ac.uk:1094//eos/antares/prod" % (os.getuid()),
     ),
     StorageElement(
         "UKI-SOUTHGRID-RALPP-disk",


### PR DESCRIPTION
A series of changes. 
`host` string is changed for the `RAL-LCG2-T2K-tape` SE, and the user ID from the is built into the `basepath` string. The deprecated `gfal-legacy-bringonline` command is replaced with the now recommended `gfal-bringonline` command.
The `host`, `directpath` and `basepath` strings are updated for `IN2P3-CC-XRD-disk` and `IN2P3-CC-XRD-tape` SEs.