### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Nothing
 
+## [1.17.5] - 2022-02-26
+### Changed
+- Updated pythonpublish.yml to fix the API token error that kept popping up when attempting to upload releases from GitHub to PyPi.
+
+## [1.17.4] - 2024-02-21
+### Changed
+- Updated pythonpublish.yml which is used for the upload Python package workflow run.
+
+## [1.17.3] - 2024-02-21
+### Changed
+- Updated the RAL-LCG2-T2K-tape, IN2P3-CC-XRD-disk and IN2P3-CC-XRD-tape SE properties, and replace the deprecated gfal-legacy-bringonline command that was used for tape SEs.
+
+## [1.17.2] - 2022-11-09
+### Changed
+- Fixed a Python 3 specific bug for T2K Data Manager Maid.
+
+## [1.17.1] - 2022-11-06
+### Changed
+- Updated the RAL-LCG2-T2K-tape SE properties, and added instructions on how to obtain a Grid certificate in README.
+
 ## [1.17.0] - 2022-09-22
 ### Changed
 - Storage at TRIUMF is now marked as broken, since we no longer use it.


### PR DESCRIPTION
Retroactively added information in `CHANGELOG.md` for all the releases made over the last 2 years. From now on, an up-to-date record of changes will be kept in `CHANGELOG.md`.