### PR TITLE
IN2P3 SEs have been updated, and error handling of the get_SE method improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
 - Basepath string for IN2P3-CC-XRD-tape and IN2P3-CC-XRD-disk is corrected (// is replaced with / for an exact string match with the host name string).
 - BackendException for cases where the get_SE method returns None because the host name string is not contained inside the file URL are added.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Nothing
+- Basepath string for IN2P3-CC-XRD-tape and IN2P3-CC-XRD-disk is corrected (// is replaced with // for an exact string match with the host name string).
+- BackendException for cases where the get_SE method returns None because the host name string is not contained inside the file URL are added.
 
 ## [1.17.0] - 2022-09-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Basepath string for IN2P3-CC-XRD-tape and IN2P3-CC-XRD-disk is corrected (// is replaced with // for an exact string match with the host name string).
+- Basepath string for IN2P3-CC-XRD-tape and IN2P3-CC-XRD-disk is corrected (// is replaced with / for an exact string match with the host name string).
 - BackendException for cases where the get_SE method returns None because the host name string is not contained inside the file URL are added.
 
 ## [1.17.5] - 2022-02-26

--- a/t2kdm/backends.py
+++ b/t2kdm/backends.py
@@ -1011,10 +1011,16 @@ class DIRACBackend(GridBackend):
 
         source = storage.get_SE(source_surl)
         if source is None:
-            raise BackendException("Could not find storage element with host name string contained inside %s." % (source_surl))
+            raise BackendException(
+                "Could not find storage element with host name string contained inside %s."
+                % (source_surl)
+            )
         destination = storage.get_SE(destination_surl)
         if destination is None:
-            raise BackendException("Could not find storage element with host name string contained inside %s." % (destination_surl))
+            raise BackendException(
+                "Could not find storage element with host name string contained inside %s."
+                % (destination_surl)
+            )
         try:
             self._replicate_cmd(lurl, destination.name, source.name, _out=out, **kwargs)
         except sh.ErrorReturnCode as e:
@@ -1054,7 +1060,10 @@ class DIRACBackend(GridBackend):
             out = None
         se = storage.get_SE(surl)
         if se is None:
-            raise BackendException("Could not find storage element with host name string contained inside %s." % (surl))
+            raise BackendException(
+                "Could not find storage element with host name string contained inside %s."
+                % (surl)
+            )
 
         try:
             self._add_cmd(lurl, localpath, se.name, _out=out, **kwargs)
@@ -1071,7 +1080,10 @@ class DIRACBackend(GridBackend):
     def _remove(self, surl, lurl, last=False, verbose=False, **kwargs):
         se = storage.get_SE(surl)
         if se is None:
-            raise BackendException("Could not find storage element with host name string contained inside %s." % (surl))
+            raise BackendException(
+                "Could not find storage element with host name string contained inside %s."
+                % (surl)
+            )
 
         if last:
             # Delete lfn

--- a/t2kdm/backends.py
+++ b/t2kdm/backends.py
@@ -1009,10 +1009,14 @@ class DIRACBackend(GridBackend):
         else:
             out = None
 
-        source = storage.get_SE(source_surl).name
-        destination = storage.get_SE(destination_surl).name
+        source = storage.get_SE(source_surl)
+        if source is None:
+            raise BackendException("Could not find storage element with host name string contained inside %s." % (source_surl))
+        destination = storage.get_SE(destination_surl)
+        if destination is None:
+            raise BackendException("Could not find storage element with host name string contained inside %s." % (destination_surl))
         try:
-            self._replicate_cmd(lurl, destination, source, _out=out, **kwargs)
+            self._replicate_cmd(lurl, destination.name, source.name, _out=out, **kwargs)
         except sh.ErrorReturnCode as e:
             if "No such file" in str(e.stderr):
                 raise DoesNotExistException("No such file or directory.")
@@ -1048,10 +1052,12 @@ class DIRACBackend(GridBackend):
             out = sys.stdout
         else:
             out = None
-        se = storage.get_SE(surl).name
+        se = storage.get_SE(surl)
+        if se is None:
+            raise BackendException("Could not find storage element with host name string contained inside %s." % (surl))
 
         try:
-            self._add_cmd(lurl, localpath, se, _out=out, **kwargs)
+            self._add_cmd(lurl, localpath, se.name, _out=out, **kwargs)
         except sh.ErrorReturnCode as e:
             if "No such file" in str(e.stderr):
                 raise DoesNotExistException("No such file or directory.")
@@ -1063,7 +1069,9 @@ class DIRACBackend(GridBackend):
         return True
 
     def _remove(self, surl, lurl, last=False, verbose=False, **kwargs):
-        se = storage.get_SE(surl).name
+        se = storage.get_SE(surl)
+        if se is None:
+            raise BackendException("Could not find storage element with host name string contained inside %s." % (surl))
 
         if last:
             # Delete lfn
@@ -1072,8 +1080,8 @@ class DIRACBackend(GridBackend):
             ret = self.dm.removeFile([lurl])
         else:
             if verbose:
-                print_("Removing replica of %s from %s." % (lurl, se))
-            ret = self.dm.removeReplica(se, [lurl])
+                print_("Removing replica of %s from %s." % (lurl, se.name))
+            ret = self.dm.removeReplica(se.name, [lurl])
 
         if not ret["OK"]:
             raise BackendException("Failed: %s" % (ret["Message"]))

--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -241,7 +241,7 @@ SEs = [
         type="disk",
         location="/europe/fr/in2p3",
         directpath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/disk/t2k.org",
-        basepath="root://ccxrdrli04.in2p3.fr:1097//xrootd/in2p3.fr/disk/t2k.org",
+        basepath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/disk/t2k.org",
     ),
     StorageElement(
         "IN2P3-CC-XRD-tape",
@@ -249,7 +249,7 @@ SEs = [
         type="tape",
         location="/europe/fr/in2p3",
         directpath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/tape/t2k.org",
-        basepath="root://ccxrdrli04.in2p3.fr:1097//xrootd/in2p3.fr/tape/t2k.org",
+        basepath="root://ccxrdrli04.in2p3.fr:1097/xrootd/in2p3.fr/tape/t2k.org",
     ),
     StorageElement(
         "IN2P3-CC-disk",


### PR DESCRIPTION
`basepath` string for `IN2P3-CC-XRD-tape` and `IN2P3-CC-XRD-disk` is corrected (`//` is replaced with `/` for an exact string match with the `host` name string).
`BackendException` for cases where the `get_SE` method returns `None` because the `host` name string is not contained inside the file URL are added.