### PR TITLE
Add new lancaster storage. Remove broken status from the old lancaste…

### DIFF
--- a/t2kdm/storage.py
+++ b/t2kdm/storage.py
@@ -199,11 +199,19 @@ SEs = [
     ),
     StorageElement(
         "UKI-NORTHGRID-LANCS-HEP-disk",
-        broken=True,
+        broken=False,
         host="fal-pygrid-30.lancs.ac.uk",
         type="disk",
-        location="/europe/uk/lancs",
+        location="/europe/uk/oldlancs",
         basepath="srm://fal-pygrid-30.lancs.ac.uk:8446/srm/managerv2?SFN=/dpm/lancs.ac.uk/home/t2k.org",
+    ),
+    StorageElement(
+        "UKI-NORTHGRID-LANCS-HEP-XGATE-disk",
+        broken=False,
+        host="xgate.hec.lancs.ac.uk",
+        type="disk",
+        location="/europe/uk/lancs",
+        basepath="root://xgate.hec.lancs.ac.uk:1094/cephfs/grid/t2k.org",
     ),
     StorageElement(
         "UKI-NORTHGRID-MAN-HEP-disk",


### PR DESCRIPTION
Added new lancaster storage.

Removed broken status from old lancaster storage since it works and we need to access it to replicate data from old to new storage.

I tested
t2kdm-put
t2kdm-replicate 

and both of these worked with the new SE.